### PR TITLE
Support additional quoting options for fields based on data type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ module.exports = function() {
 };
 
 Stringifier = function(options) {
-  var _base, _base1, _base2, _base3, _base4, _base5, _base6, _base7, _base8;
+  var _base, _base1, _base2, _base3, _base4, _base5, _base6, _base7, _base8, _base9;
   if (options == null) {
     options = {};
   }
@@ -81,23 +81,26 @@ Stringifier = function(options) {
   if ((_base2 = this.options).quoted == null) {
     _base2.quoted = false;
   }
-  if ((_base3 = this.options).eof == null) {
-    _base3.eof = true;
+  if ((_base3 = this.options).quotedString == null) {
+    _base3.quotedString = false;
   }
-  if ((_base4 = this.options).escape == null) {
-    _base4.escape = '"';
+  if ((_base4 = this.options).eof == null) {
+    _base4.eof = true;
   }
-  if ((_base5 = this.options).columns == null) {
-    _base5.columns = null;
+  if ((_base5 = this.options).escape == null) {
+    _base5.escape = '"';
   }
-  if ((_base6 = this.options).header == null) {
-    _base6.header = false;
+  if ((_base6 = this.options).columns == null) {
+    _base6.columns = null;
   }
-  if ((_base7 = this.options).lineBreaks == null) {
-    _base7.lineBreaks = null;
+  if ((_base7 = this.options).header == null) {
+    _base7.header = false;
   }
-  if ((_base8 = this.options).rowDelimiter == null) {
-    _base8.rowDelimiter = '\n';
+  if ((_base8 = this.options).lineBreaks == null) {
+    _base8.lineBreaks = null;
+  }
+  if ((_base9 = this.options).rowDelimiter == null) {
+    _base9.rowDelimiter = '\n';
   }
   if (this.countWriten == null) {
     this.countWriten = 0;
@@ -254,10 +257,12 @@ Stringifier.prototype.stringify = function(line) {
           regexp = new RegExp(quote, 'g');
           field = field.replace(regexp, escape + quote);
         }
-        if (containsQuote || containsdelimiter || containsLinebreak || this.options.quoted) {
+        if (containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || (this.options.quotedString && typeof line[i] === 'string')) {
           field = quote + field + quote;
         }
         newLine += field;
+      } else if (this.options.quotedEmpty || ((this.options.quotedEmpty == null) && line[i] === '' && this.options.quotedString)) {
+        newLine += quote + quote;
       }
       if (i !== line.length - 1) {
         newLine += delimiter;

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -63,7 +63,9 @@ Options may include:
 *   `header`        Display the column names on the first line if the columns option is provided or discovered.   
 *   `lineBreaks`    String used to delimit record rows or a special value; special values are 'auto', 'unix', 'mac', 'windows', 'unicode'; defaults to 'auto' (discovered in source or 'unix' if no source is specified).   
 *   `quote`         Defaults to the quote read option.   
-*   `quoted`        Boolean, default to false, quote all the fields even if not required.   
+*   `quoted`        Boolean, default to false, quote all the non-empty fields even if not required.
+*   `quotedEmpty`   Boolean, no default, quote empty fields?  If specified, overrides `quotedString` for empty strings.
+*   `quotedString`  Boolean, default to false, quote all fields of type string even if not required.
 *   `rowDelimiter`  String used to delimit record rows or a special value; special values are 'auto', 'unix', 'mac', 'windows', 'unicode'; defaults to 'auto' (discovered in source or 'unix' if no source is specified).   
 
 All options are optional.
@@ -75,6 +77,7 @@ All options are optional.
       @options.delimiter ?= ','
       @options.quote ?= '"'
       @options.quoted ?= false
+      @options.quotedString ?= false
       @options.eof ?= true
       @options.escape ?= '"'
       @options.columns ?= null
@@ -194,9 +197,11 @@ Convert a line to a string. Line may be an object, an array or a string.
             if containsQuote
               regexp = new RegExp(quote,'g')
               field = field.replace(regexp, escape + quote)
-            if containsQuote or containsdelimiter or containsLinebreak or @options.quoted
+            if containsQuote or containsdelimiter or containsLinebreak or @options.quoted or (@options.quotedString and typeof line[i] is 'string')
               field = quote + field + quote
             newLine += field
+          else if @options.quotedEmpty or (not @options.quotedEmpty? and line[i] is '' and @options.quotedString)
+            newLine += quote + quote
           if i isnt line.length - 1
             newLine += delimiter
         line = newLine

--- a/test/quotedEmpty.coffee
+++ b/test/quotedEmpty.coffee
@@ -1,0 +1,77 @@
+
+fs = require 'fs'
+should = require 'should'
+stringify = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+
+describe 'quotedEmpty', ->
+  it 'quotes empty fields (when all not quoted)', (next) ->
+    count = 0
+    data = ''
+    stringifier = stringify quoted: false, quotedEmpty: true, eof: false
+    stringifier.on 'readable', ->
+      while(d = stringifier.read())
+        data += d
+    stringifier.on 'record', (record, index) ->
+      count++
+    stringifier.on 'finish', ->
+      count.should.eql 1
+      data.should.eql """
+      "","","", ,0,""
+      """
+      next()
+    stringifier.write [ undefined,null,'',' ',0,false ]
+    stringifier.end()
+
+  it 'quotes empty fields (when strings quoted)', (next) ->
+    count = 0
+    data = ''
+    stringifier = stringify quotedEmpty: true, quotedString: true, eof: false
+    stringifier.on 'readable', ->
+      while(d = stringifier.read())
+        data += d
+    stringifier.on 'record', (record, index) ->
+      count++
+    stringifier.on 'finish', ->
+      count.should.eql 1
+      data.should.eql """
+      "","",""," ",0,""
+      """
+      next()
+    stringifier.write [ undefined,null,'',' ',0,false ]
+    stringifier.end()
+
+  it 'prevents quoting empty fields (when strings quoted)', (next) ->
+    count = 0
+    data = ''
+    stringifier = stringify quotedEmpty: false, quotedString: true, eof: false
+    stringifier.on 'readable', ->
+      while(d = stringifier.read())
+        data += d
+    stringifier.on 'record', (record, index) ->
+      count++
+    stringifier.on 'finish', ->
+      count.should.eql 1
+      data.should.eql """
+      ,,," ",0,
+      """
+      next()
+    stringifier.write [ undefined,null,'',' ',0,false ]
+    stringifier.end()
+
+  it 'quotes empty fields (when all quoted)', (next) ->
+    count = 0
+    data = ''
+    stringifier = stringify quoted: true, quotedEmpty: true, eof: false
+    stringifier.on 'readable', ->
+      while(d = stringifier.read())
+        data += d
+    stringifier.on 'record', (record, index) ->
+      count++
+    stringifier.on 'finish', ->
+      count.should.eql 1
+      data.should.eql """
+      "","",""," ","0",""
+      """
+      next()
+    stringifier.write [ undefined,null,'',' ',0,false ]
+    stringifier.end()

--- a/test/quotedString.coffee
+++ b/test/quotedString.coffee
@@ -1,0 +1,42 @@
+
+fs = require 'fs'
+should = require 'should'
+stringify = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+
+describe 'quotedString', ->
+  
+  it 'quotes string fields', (next) ->
+    count = 0
+    data = ''
+    stringifier = stringify quotedString: true, eof: false
+    stringifier.on 'readable', ->
+      while(d = stringifier.read())
+        data += d
+    stringifier.on 'record', (record, index) ->
+      count++
+    stringifier.on 'finish', ->
+      count.should.eql 1
+      data.should.eql """
+      ,,""," ","x",0,
+      """
+      next()
+    stringifier.write [ undefined,null,'',' ','x',0,false ]
+    stringifier.end()
+
+  it 'quotes empty string fields (when all quoted)', (next) ->
+    count = 0
+    data = ''
+    stringifier = stringify quoted: true, quotedString: true, eof: false
+    stringifier.on 'readable', ->
+      while(d = stringifier.read())
+        data += d
+    stringifier.on 'record', (record, index) ->
+      count++
+    stringifier.on 'finish', ->
+      count.should.eql 1
+      data.should.eql """
+      ,,""," ","x","0",
+      """
+      next()
+    stringifier.write [ undefined,null,'',' ','x',0,false ]
+    stringifier.end()


### PR DESCRIPTION
For writing CSV files which are consumed by applications that distinguish data types for fields based on how the fields are quoted, it would be great if node-csv-stringify supported some additional options to preserve this information.  This pull request adds two such options:

In order to support CSV processors which distinguish between string and non-string values, add the `quotedString` option which unconditionally quotes all string values.  This option can be used with the `quoted` option to quote empty string values, but it does not override the `quoted` option (as I can not currently think of a use case where quoting everything but strings would be desirable).

In order to support CSV processors which distinguish between missing/unspecified values and empty strings (i.e. null vs empty string), add the `quotedEmpty` option to specify whether empty values are quoted.  This option overrides quoted and `quotedString` to allow users to allow quoting only empty values (to avoid the overhead of quoting all strings while still distinguishing empty from missing values) and to avoid quoting empty strings when they should be treated as missing by the CSV consumer.

I hope you find it useful.

Kevin
