### PR TITLE
Stringify sub objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -248,6 +248,8 @@ Stringifier.prototype.stringify = function(line) {
         field = field ? '1' : '';
       } else if (field instanceof Date) {
         field = '' + field.getTime();
+      } else if (typeof field === 'object') {
+        field = JSON.stringify(field);        
       }
       if (field) {
         containsdelimiter = field.indexOf(delimiter) >= 0;


### PR DESCRIPTION
Calls `JSON.stringify` on objects inside the top-level row object.

Fixes #14.
