### PR TITLE
Allow empty quote value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Trunk
+
+* package: allow empty quote value
+
 ## Version 2.0.4
 
 * package: move babel to dev dependencies
@@ -21,8 +25,8 @@
 
 ## 2.0.0
 
-This major version use CoffeeScript 2 which produces a modern JavaScript syntax 
-(ES6, or ES2015 and later) and break the compatibility with versions of Node.js 
+This major version use CoffeeScript 2 which produces a modern JavaScript syntax
+(ES6, or ES2015 and later) and break the compatibility with versions of Node.js
 lower than 7.6 as well as the browsers. It is however stable in term of API.
 
 * package: use CoffeeScript 2

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Usage
 -----
 
 Refer to the [project webpage][home] for [an exhaustive list of options][home]
-and [some usage examples][examples]. 
+and [some usage examples][examples].
 
-The module is built on the Node.js Stream API. For the sake of simplify, a
+The module is built on the Node.js Stream API. For the sake of simplicity, a
 simple callback API is also provided. To give you a quick look, here's an
 example of the callback API:
 
@@ -35,21 +35,21 @@ var stringify = require('csv-stringify');
 
 input = [ [ '1', '2', '3', '4' ], [ 'a', 'b', 'c', 'd' ] ];
 stringify(input, function(err, output){
-  output.should.eql('1,2,3,4\na,b,c,d');
+  output.should.eql('1,2,3,4\na,b,c,d\n');
 });
 ```
 
 Development
 -----------
 
-Tests are executed with mocha. To install it, simple run `npm install` 
-followed by `npm test`. It will install mocha and its dependencies in your 
-project "node_modules" directory and run the test suite. The tests run 
+Tests are executed with mocha. To install it, run `npm install`
+followed by `npm test`. It will install mocha and its dependencies in your
+project "node_modules" directory and run the test suite. The tests run
 against the CoffeeScript source files.
 
 To generate the JavaScript files, run `npm run coffee`.
 
-The test suite is run online with [Travis][travis] against the versions 
+The test suite is run online with [Travis][travis] against the versions
 0.10, 0.11 and 0.12 of Node.js.
 
 Contributors
@@ -58,6 +58,8 @@ Contributors
 *   David Worms: <https://github.com/wdavidw>
 
 [home]: http://csv.adaltas.com/stringify/
+[csv_home]: https://github.com/adaltas/node-csv
+[stream_transform]: http://nodejs.org/api/stream.html#stream_class_stream_transform
 [examples]: http://csv.adaltas.com/stringify/examples/
 [csv]: https://github.com/adaltas/node-csv
 [travis]: https://travis-ci.org/#!/adaltas/node-csv-stringify

--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -338,7 +338,7 @@ Stringifier.prototype.stringify = function (line) {
           return this.emit('error', Error('Formatter must return a string, null or undefined'));
         }
         containsdelimiter = field.indexOf(delimiter) >= 0;
-        containsQuote = field.indexOf(quote) >= 0;
+        containsQuote = quote !== '' && field.indexOf(quote) >= 0;
         containsEscape = field.indexOf(escape) >= 0 && escape !== quote;
         containsLinebreak = field.indexOf('\r') >= 0 || field.indexOf('\n') >= 0;
         shouldQuote = containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || this.options.quotedString && typeof line[i] === 'string';

--- a/lib/index.js
+++ b/lib/index.js
@@ -331,7 +331,7 @@ Stringifier.prototype.stringify = function(line) {
           return this.emit('error', Error('Formatter must return a string, null or undefined'));
         }
         containsdelimiter = field.indexOf(delimiter) >= 0;
-        containsQuote = field.indexOf(quote) >= 0;
+        containsQuote = (quote !== '') && field.indexOf(quote) >= 0;
         containsEscape = field.indexOf(escape) >= 0 && (escape !== quote);
         containsLinebreak = field.indexOf('\r') >= 0 || field.indexOf('\n') >= 0;
         shouldQuote = containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || (this.options.quotedString && typeof line[i] === 'string');

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -205,7 +205,7 @@ Convert a line to a string. Line may be an object, an array or a string.
           if field
             return @emit 'error', Error 'Formatter must return a string, null or undefined' unless typeof field is 'string'
             containsdelimiter = field.indexOf(delimiter) >= 0
-            containsQuote = field.indexOf(quote) >= 0
+            containsQuote = (quote isnt '') and field.indexOf(quote) >= 0
             containsEscape = field.indexOf(escape) >= 0 and (escape isnt quote)
             containsLinebreak = field.indexOf('\r') >= 0 or field.indexOf('\n') >= 0
             shouldQuote = containsQuote or containsdelimiter or containsLinebreak or @options.quoted or (@options.quotedString and typeof line[i] is 'string')

--- a/test/quote.coffee
+++ b/test/quote.coffee
@@ -3,7 +3,7 @@ fs = require 'fs'
 stringify = require '../src'
 
 describe 'quote', ->
-  
+
   it 'with separator inside fields',  (next) ->
     stringify [
       [ '20322051544','1979.0','8.8017226E7','ABC,45','2000-01-01' ]
@@ -14,7 +14,7 @@ describe 'quote', ->
       28392898392,1974.0,8.8392926E7,DEF,23,2050-11-27
       """
       next()
-    
+
   it 'with values containing delimiters', (next) ->
     stringify [
       [ '20322051544',',1979.0,8.8017226E7,ABC,45,2000-01-01' ]
@@ -27,7 +27,7 @@ describe 'quote', ->
       "28392898392,1974.0",8.8392926E7,"DEF,23,2050-11-27,"
       """
       next()
-    
+
   it 'with fields containing quotes', (next) ->
     stringify [
       [ '20322051544','1979.0','8.801"7226E7','ABC','45','2000-01-01' ]
@@ -38,7 +38,7 @@ describe 'quote', ->
       28392898392,1974.0,8.8392926E7,DEF,"2""3",2050-11-27
       """
       next()
-    
+
   it 'empty value', (next) ->
     stringify [
       [ '20322051544','','8.8017226E7','45','' ]
@@ -49,7 +49,7 @@ describe 'quote', ->
       ,1974,8.8392926E7,,
       """
       next()
-    
+
   it 'values containing quotes and double quotes escape', (next) ->
     stringify [
       [ '20322051544','"','8.8017226E7',45,'"ok"' ]
@@ -60,7 +60,7 @@ describe 'quote', ->
       ,1974,8.8392926E7,,
       """
       next()
-    
+
   it 'line breaks inside quotes', (next) ->
     stringify [
       [ '20322051544','\n',',8.8017226E7',45,'\nok\n' ]
@@ -74,5 +74,16 @@ describe 'quote', ->
       "
       ",1974,8.8392926E7,,"
       "
+      """
+      next()
+
+  it 'values where quote string is empty', (next) ->
+    stringify [
+      [ '20322051544','"','8.8017226E7',45,'"ok"' ]
+      [ '','1974','8.8392926E7','','' ]
+    ], {eof: false, quote: ''}, (err, data) ->
+      data.should.eql """
+      20322051544,\",8.8017226E7,45,\"ok\"
+      ,1974,8.8392926E7,,
       """
       next()


### PR DESCRIPTION
I've separated this out into 4 commits, each a little bit more contentious than the previous. Happy to split this up as separate PRs if required. **DONE**

The 2 important introductions are:

* [Allow an empty quote to be applied](https://github.com/adaltas/node-csv-stringify/pull/60/commits/79f659859c3f66f96b7bf286fc1d484da37c352e) - this allows quoting to be disabled completely
* ~~[Don't blindly quote linebreaks](https://github.com/adaltas/node-csv-stringify/pull/60/commits/ea02bbf831acd3e609fe2847396fba43239c97cf) - it should really only be quoting rowDelimiters, which in _most_ cases are a linebreak~~ (separated this out per request below)
