### PR TITLE
add ASCII option for rowDelimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Trunk
 
 * package: allow empty quote value
+* package: add ascii option for rowDelimiter
 
 ## Version 2.0.4
 

--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -183,6 +183,9 @@ Stringifier = function Stringifier() {
     case 'windows':
       this.options.rowDelimiter = "\r\n";
       break;
+    case 'ascii':
+      this.options.rowDelimiter = '\x1E';
+      break;
     case 'unicode':
       this.options.rowDelimiter = '\u2028';
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,6 +177,9 @@ Stringifier = function(opts = {}) {
     case 'windows':
       this.options.rowDelimiter = "\r\n";
       break;
+    case 'ascii':
+      this.options.rowDelimiter = "\u001e";
+      break;
     case 'unicode':
       this.options.rowDelimiter = "\u2028";
   }

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -106,6 +106,8 @@ Options are documented [here](http://csv.adaltas.com/stringify/).
           @options.rowDelimiter = "\r"
         when 'windows'
           @options.rowDelimiter = "\r\n"
+        when 'ascii'
+          @options.rowDelimiter = "\u001e"
         when 'unicode'
           @options.rowDelimiter = "\u2028"
       @

--- a/test/options.rowDelimiter.coffee
+++ b/test/options.rowDelimiter.coffee
@@ -11,7 +11,7 @@ describe 'options rowDelimiter', ->
       return next err if err
       result.should.eql '20322051544,8.8017226E7,ABC::28392898392,8.8392926E7,DEF::'
       next()
-  
+
   it 'Test line breaks unix', (next) ->
     stringify [
       [ '20322051544','8.8017226E7','ABC' ]
@@ -20,7 +20,7 @@ describe 'options rowDelimiter', ->
       return next err if err
       result.should.eql '20322051544,8.8017226E7,ABC\n28392898392,8.8392926E7,DEF\n'
       next()
-  
+
   it 'Test line breaks unicode', (next) ->
     stringify [
       [ '20322051544','8.8017226E7','ABC' ]
@@ -29,7 +29,7 @@ describe 'options rowDelimiter', ->
       return next err if err
       result.should.eql '20322051544,8.8017226E7,ABC\u202828392898392,8.8392926E7,DEF\u2028'
       next()
-  
+
   it 'Test line breaks mac', (next) ->
     stringify [
       [ '20322051544','8.8017226E7','ABC' ]
@@ -38,7 +38,7 @@ describe 'options rowDelimiter', ->
       return next err if err
       result.should.eql '20322051544,8.8017226E7,ABC\r28392898392,8.8392926E7,DEF\r'
       next()
-  
+
   it 'Test line breaks windows', (next) ->
     stringify [
       [ '20322051544','8.8017226E7','ABC' ]
@@ -47,4 +47,13 @@ describe 'options rowDelimiter', ->
       return next err if err
       result.should.eql '20322051544,8.8017226E7,ABC\r\n28392898392,8.8392926E7,DEF\r\n'
       next()
-  
+
+  it 'Test line breaks ascii', (next) ->
+    stringify [
+      [ '20322051544','8.8017226E7','ABC' ]
+      [ '28392898392','8.8392926E7','DEF' ]
+    ], {rowDelimiter: 'ascii', delimiter: '\u001f'}, (err, result) ->
+      return next err if err
+      result.should.eql '20322051544\u001f8.8017226E7\u001fABC\u001e28392898392\u001f8.8392926E7\u001fDEF\u001e'
+      next()
+


### PR DESCRIPTION
This option uses the [C0 control code](https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_(ASCII_and_derivatives)) `U+001E RECORD SEPARATOR` to delimit the rows. expectation is that in this case, `delimiter` would be `U+001F UNIT SEPARATOR`. Of course this is possible by declaring the `rowDelimiter` manually, but I thought it may be useful to call out the ASCII standard here.