### PR TITLE
Switch linebreak check for rowDelimiter check

### DIFF
--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -287,7 +287,7 @@ Stringifier.prototype._transform = function (chunk, encoding, callback) {
 
 // Convert a line to a string. Line may be an object, an array or a string.
 Stringifier.prototype.stringify = function (line) {
-  var _line, column, columns, containsEscape, containsLinebreak, containsQuote, containsdelimiter, delimiter, escape, field, i, j, l, newLine, quote, ref, ref1, regexp, shouldQuote, value;
+  var _line, column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, delimiter, escape, field, i, j, l, newLine, quote, ref, ref1, regexp, shouldQuote, value;
   if ((typeof line === 'undefined' ? 'undefined' : _typeof(line)) !== 'object') {
     return line;
   }
@@ -343,8 +343,8 @@ Stringifier.prototype.stringify = function (line) {
         containsdelimiter = field.indexOf(delimiter) >= 0;
         containsQuote = quote !== '' && field.indexOf(quote) >= 0;
         containsEscape = field.indexOf(escape) >= 0 && escape !== quote;
-        containsLinebreak = field.indexOf('\r') >= 0 || field.indexOf('\n') >= 0;
-        shouldQuote = containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || this.options.quotedString && typeof line[i] === 'string';
+        containsRowDelimiter = field.indexOf(this.options.rowDelimiter) >= 0;
+        shouldQuote = containsQuote || containsdelimiter || containsRowDelimiter || this.options.quoted || this.options.quotedString && typeof line[i] === 'string';
         if (shouldQuote && containsEscape) {
           regexp = escape === '\\' ? new RegExp(escape + escape, 'g') : new RegExp(escape, 'g');
           field = field.replace(regexp, escape + escape);

--- a/lib/index.js
+++ b/lib/index.js
@@ -281,7 +281,7 @@ Stringifier.prototype._transform = function(chunk, encoding, callback) {
 
 // Convert a line to a string. Line may be an object, an array or a string.
 Stringifier.prototype.stringify = function(line) {
-  var _line, column, columns, containsEscape, containsLinebreak, containsQuote, containsdelimiter, delimiter, escape, field, i, j, l, newLine, quote, ref, ref1, regexp, shouldQuote, value;
+  var _line, column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, delimiter, escape, field, i, j, l, newLine, quote, ref, ref1, regexp, shouldQuote, value;
   if (typeof line !== 'object') {
     return line;
   }
@@ -336,8 +336,8 @@ Stringifier.prototype.stringify = function(line) {
         containsdelimiter = field.indexOf(delimiter) >= 0;
         containsQuote = (quote !== '') && field.indexOf(quote) >= 0;
         containsEscape = field.indexOf(escape) >= 0 && (escape !== quote);
-        containsLinebreak = field.indexOf('\r') >= 0 || field.indexOf('\n') >= 0;
-        shouldQuote = containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || (this.options.quotedString && typeof line[i] === 'string');
+        containsRowDelimiter = field.indexOf(this.options.rowDelimiter) >= 0;
+        shouldQuote = containsQuote || containsdelimiter || containsRowDelimiter || this.options.quoted || (this.options.quotedString && typeof line[i] === 'string');
         if (shouldQuote && containsEscape) {
           regexp = escape === '\\' ? new RegExp(escape + escape, 'g') : new RegExp(escape, 'g');
           field = field.replace(regexp, escape + escape);

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -209,8 +209,8 @@ Convert a line to a string. Line may be an object, an array or a string.
             containsdelimiter = field.indexOf(delimiter) >= 0
             containsQuote = (quote isnt '') and field.indexOf(quote) >= 0
             containsEscape = field.indexOf(escape) >= 0 and (escape isnt quote)
-            containsLinebreak = field.indexOf('\r') >= 0 or field.indexOf('\n') >= 0
-            shouldQuote = containsQuote or containsdelimiter or containsLinebreak or @options.quoted or (@options.quotedString and typeof line[i] is 'string')
+            containsRowDelimiter = field.indexOf(@options.rowDelimiter) >= 0
+            shouldQuote = containsQuote or containsdelimiter or containsRowDelimiter or @options.quoted or (@options.quotedString and typeof line[i] is 'string')
             if shouldQuote and containsEscape
               regexp = if escape is '\\' then new RegExp(escape + escape, 'g') else new RegExp(escape, 'g');
               field = field.replace(regexp, escape + escape)

--- a/test/quote.coffee
+++ b/test/quote.coffee
@@ -87,3 +87,14 @@ describe 'quote', ->
       ,1974,8.8392926E7,,
       """
       next()
+
+  it 'values with linebreaks and different rowDelimiter', (next) ->
+    stringify [
+      [ '123\n456', 789]
+      [ '','1974' ]
+    ], {eof: false, rowDelimiter: '__'}, (err, data) ->
+      data.should.eql """
+      123
+      456,789__,1974
+      """
+      next()


### PR DESCRIPTION
**Warning: BC breaking change**

The decision for when to quote is currently based on whether the field contains a linebreak. This feels like it should actually be a check on the `rowDelimiter`, which in a number of cases will be a linebreak, but not always.

Following on from comments in #60, this does merit some discussion about if this is an acceptable change and what the desired behaviour is. Strictly speaking as it breaks BC, it should be a major version bump as it stands.