### PR TITLE
Replace deprecated lodash.get dependency

### DIFF
--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -10,7 +10,7 @@ var _Stringifier, get, stream, util;
 
 stream = require('stream');
 util = require('util');
-get = require('lodash.get'); // ## Usage
+get = require('lodash/get'); // ## Usage
 // This module export a function as its main entry point and return a transform
 // stream.
 // Refers to the [official prject documentation](http://csv.adaltas.com/stringify/)

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ stream = require('stream');
 
 util = require('util');
 
-get = require('lodash.get');
+get = require('lodash/get');
 
 // ## Usage
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://csv.js.org/stringify/",
   "dependencies": {
-    "lodash.get": "~4.4.2"
+    "lodash": "~4.17.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -6,7 +6,7 @@ information.
 
     stream = require 'stream'
     util = require 'util'
-    get = require 'lodash.get'
+    get = require 'lodash/get'
 
 ## Usage
 


### PR DESCRIPTION
Per https://github.com/lodash/lodash/issues/3744#issuecomment-409127068, the modularized `lodash` packages are deprecated. Let's use `lodash/get` instead of `lodash.get`!