### PR TITLE
Issue88

### DIFF
--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -405,7 +405,7 @@ function (_stream$Transform) {
   }, {
     key: "stringify",
     value: function stringify(chunk) {
-      var column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, delimiter, err, escape, field, header, i, j, l, len, m, newrecord, quote, quoted, quotedMatch, quotedString, record, ref, ref1, regexp, shouldQuote, value;
+      var column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, err, field, header, i, j, l, len, m, mergedOptions, newrecord, options, quoted, quotedMatch, quotedString, record, ref, ref1, regexp, shouldQuote, value;
 
       if (_typeof(chunk) !== 'object') {
         return chunk;
@@ -413,10 +413,7 @@ function (_stream$Transform) {
 
       var _this$options = this.options;
       columns = _this$options.columns;
-      delimiter = _this$options.delimiter;
       header = _this$options.header;
-      quote = _this$options.quote;
-      escape = _this$options.escape;
       record = []; // Record is an array
 
       if (Array.isArray(chunk)) {
@@ -506,7 +503,7 @@ function (_stream$Transform) {
         for (i = m = 0, ref1 = record.length; 0 <= ref1 ? m < ref1 : m > ref1; i = 0 <= ref1 ? ++m : --m) {
           var _record$i = _slicedToArray(record[i], 2);
 
-          value = _record$i[0];
+          options = _record$i[0];
           field = _record$i[1];
 
           if (err) {
@@ -514,19 +511,28 @@ function (_stream$Transform) {
             return;
           }
 
+          if (options && _typeof(options) === 'object') {
+            value = options.value;
+          } else {
+            value = options;
+            options = {};
+          }
+
+          mergedOptions = Object.assign({}, this.options, options);
+
           if (value) {
             if (typeof value !== 'string') {
               this.emit('error', Error("Formatter must return a string, null or undefined, got ".concat(JSON.stringify(value))));
               return null;
             }
 
-            containsdelimiter = value.indexOf(delimiter) >= 0;
-            containsQuote = quote !== '' && value.indexOf(quote) >= 0;
-            containsEscape = value.indexOf(escape) >= 0 && escape !== quote;
-            containsRowDelimiter = value.indexOf(this.options.record_delimiter) >= 0;
-            quoted = this.options.quoted;
-            quotedString = this.options.quoted_string && typeof field === 'string';
-            quotedMatch = this.options.quoted_match && typeof field === 'string' && this.options.quoted_match.filter(function (quoted_match) {
+            containsdelimiter = value.indexOf(mergedOptions.delimiter) >= 0;
+            containsQuote = mergedOptions.quote !== '' && value.indexOf(mergedOptions.quote) >= 0;
+            containsEscape = value.indexOf(mergedOptions.escape) >= 0 && mergedOptions.escape !== mergedOptions.quote;
+            containsRowDelimiter = value.indexOf(mergedOptions.record_delimiter) >= 0;
+            quoted = mergedOptions.quoted;
+            quotedString = mergedOptions.quoted_string && typeof field === 'string';
+            quotedMatch = mergedOptions.quoted_match && typeof field === 'string' && mergedOptions.quoted_match.filter(function (quoted_match) {
               if (typeof quoted_match === 'string') {
                 return value.indexOf(quoted_match) !== -1;
               } else {
@@ -537,26 +543,26 @@ function (_stream$Transform) {
             shouldQuote = containsQuote || containsdelimiter || containsRowDelimiter || quoted || quotedString || quotedMatch;
 
             if (shouldQuote && containsEscape) {
-              regexp = escape === '\\' ? new RegExp(escape + escape, 'g') : new RegExp(escape, 'g');
-              value = value.replace(regexp, escape + escape);
+              regexp = mergedOptions.escape === '\\' ? new RegExp(mergedOptions.escape + mergedOptions.escape, 'g') : new RegExp(mergedOptions.escape, 'g');
+              value = value.replace(regexp, mergedOptions.escape + mergedOptions.escape);
             }
 
             if (containsQuote) {
-              regexp = new RegExp(quote, 'g');
-              value = value.replace(regexp, escape + quote);
+              regexp = new RegExp(mergedOptions.quote, 'g');
+              value = value.replace(regexp, mergedOptions.escape + mergedOptions.quote);
             }
 
             if (shouldQuote) {
-              value = quote + value + quote;
+              value = mergedOptions.quote + value + mergedOptions.quote;
             }
 
             newrecord += value;
-          } else if (this.options.quoted_empty || this.options.quoted_empty == null && field === '' && this.options.quoted_string) {
-            newrecord += quote + quote;
+          } else if (mergedOptions.quoted_empty || mergedOptions.quoted_empty == null && field === '' && mergedOptions.quoted_string) {
+            newrecord += mergedOptions.quote + mergedOptions.quote;
           }
 
           if (i !== record.length - 1) {
-            newrecord += delimiter;
+            newrecord += mergedOptions.delimiter;
           }
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,7 +318,7 @@ Stringifier = class Stringifier extends stream.Transform {
 
   // Convert a line to a string. Line may be an object, an array or a string.
   stringify(chunk) {
-    var column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, err, field, header, i, j, l, len, m, newrecord, quoted, quotedMatch, quotedString, record, ref, ref1, regexp, shouldQuote, value, options, mergedOptions;
+    var column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, err, field, header, i, j, l, len, m, mergedOptions, newrecord, options, quoted, quotedMatch, quotedString, record, ref, ref1, regexp, shouldQuote, value;
     if (typeof chunk !== 'object') {
       return chunk;
     }
@@ -384,17 +384,17 @@ Stringifier = class Stringifier extends stream.Transform {
       newrecord = '';
       for (i = m = 0, ref1 = record.length; (0 <= ref1 ? m < ref1 : m > ref1); i = 0 <= ref1 ? ++m : --m) {
         [options, field] = record[i];
-        if (options && (typeof options === 'object')) {
+        if (err) {
+          this.emit('error', err);
+          return;
+        }
+        if (options && typeof options === 'object') {
           value = options.value;
         } else {
           value = options;
           options = {};
         }
         mergedOptions = Object.assign({}, this.options, options);
-        if (err) {
-          this.emit('error', err);
-          return;
-        }
         if (value) {
           if (typeof value !== 'string') {
             this.emit('error', Error(`Formatter must return a string, null or undefined, got ${JSON.stringify(value)}`));

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,11 +318,11 @@ Stringifier = class Stringifier extends stream.Transform {
 
   // Convert a line to a string. Line may be an object, an array or a string.
   stringify(chunk) {
-    var column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, delimiter, err, escape, field, header, i, j, l, len, m, newrecord, quote, quoted, quotedMatch, quotedString, record, ref, ref1, regexp, shouldQuote, value;
+    var column, columns, containsEscape, containsQuote, containsRowDelimiter, containsdelimiter, err, field, header, i, j, l, len, m, newrecord, quoted, quotedMatch, quotedString, record, ref, ref1, regexp, shouldQuote, value, options, mergedOptions;
     if (typeof chunk !== 'object') {
       return chunk;
     }
-    ({columns, delimiter, header, quote, escape} = this.options);
+    ({columns, header} = this.options);
     record = [];
     // Record is an array
     if (Array.isArray(chunk)) {
@@ -383,7 +383,14 @@ Stringifier = class Stringifier extends stream.Transform {
     if (Array.isArray(record)) {
       newrecord = '';
       for (i = m = 0, ref1 = record.length; (0 <= ref1 ? m < ref1 : m > ref1); i = 0 <= ref1 ? ++m : --m) {
-        [value, field] = record[i];
+        [options, field] = record[i];
+        if (options && (typeof options === 'object')) {
+          value = options.value;
+        } else {
+          value = options;
+          options = {};
+        }
+        mergedOptions = Object.assign({}, this.options, options);
         if (err) {
           this.emit('error', err);
           return;
@@ -393,13 +400,13 @@ Stringifier = class Stringifier extends stream.Transform {
             this.emit('error', Error(`Formatter must return a string, null or undefined, got ${JSON.stringify(value)}`));
             return null;
           }
-          containsdelimiter = value.indexOf(delimiter) >= 0;
-          containsQuote = (quote !== '') && value.indexOf(quote) >= 0;
-          containsEscape = value.indexOf(escape) >= 0 && (escape !== quote);
-          containsRowDelimiter = value.indexOf(this.options.record_delimiter) >= 0;
-          quoted = this.options.quoted;
-          quotedString = this.options.quoted_string && typeof field === 'string';
-          quotedMatch = this.options.quoted_match && typeof field === 'string' && this.options.quoted_match.filter(function(quoted_match) {
+          containsdelimiter = value.indexOf(mergedOptions.delimiter) >= 0;
+          containsQuote = (mergedOptions.quote !== '') && value.indexOf(mergedOptions.quote) >= 0;
+          containsEscape = value.indexOf(mergedOptions.escape) >= 0 && (mergedOptions.escape !== mergedOptions.quote);
+          containsRowDelimiter = value.indexOf(mergedOptions.record_delimiter) >= 0;
+          quoted = mergedOptions.quoted;
+          quotedString = mergedOptions.quoted_string && typeof field === 'string';
+          quotedMatch = mergedOptions.quoted_match && typeof field === 'string' && mergedOptions.quoted_match.filter(function(quoted_match) {
             if (typeof quoted_match === 'string') {
               return value.indexOf(quoted_match) !== -1;
             } else {
@@ -409,22 +416,22 @@ Stringifier = class Stringifier extends stream.Transform {
           quotedMatch = quotedMatch && quotedMatch.length > 0;
           shouldQuote = containsQuote || containsdelimiter || containsRowDelimiter || quoted || quotedString || quotedMatch;
           if (shouldQuote && containsEscape) {
-            regexp = escape === '\\' ? new RegExp(escape + escape, 'g') : new RegExp(escape, 'g');
-            value = value.replace(regexp, escape + escape);
+            regexp = mergedOptions.escape === '\\' ? new RegExp(mergedOptions.escape + mergedOptions.escape, 'g') : new RegExp(mergedOptions.escape, 'g');
+            value = value.replace(regexp, mergedOptions.escape + mergedOptions.escape);
           }
           if (containsQuote) {
-            regexp = new RegExp(quote, 'g');
-            value = value.replace(regexp, escape + quote);
+            regexp = new RegExp(mergedOptions.quote, 'g');
+            value = value.replace(regexp, mergedOptions.escape + mergedOptions.quote);
           }
           if (shouldQuote) {
-            value = quote + value + quote;
+            value = mergedOptions.quote + value + mergedOptions.quote;
           }
           newrecord += value;
-        } else if (this.options.quoted_empty || ((this.options.quoted_empty == null) && field === '' && this.options.quoted_string)) {
-          newrecord += quote + quote;
+        } else if (mergedOptions.quoted_empty || ((mergedOptions.quoted_empty == null) && field === '' && mergedOptions.quoted_string)) {
+          newrecord += mergedOptions.quote + mergedOptions.quote;
         }
         if (i !== record.length - 1) {
-          newrecord += delimiter;
+          newrecord += mergedOptions.delimiter;
         }
       }
       record = newrecord;


### PR DESCRIPTION
It took me some time to recall how to write in coffeescript. I didn't even remember that it could be written in `.md` files :)
I've used `Object.assign` internally to merge between `@options` and the options returned by the `__cast` function (in case it returns an object).
I did not write any validations on the options returned by the `__cast` function and did not write any test that actually uses the new feature.
However, all the existing tests pass.

https://github.com/adaltas/node-csv-stringify/issues/88

