### PR TITLE
Fix get on undefined objects - Breaking change in 5.3.1

### DIFF
--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -800,7 +800,7 @@ get = function get(object, path) {
   index = 0;
   length = path.length;
 
-  while (object !== null && index < length) {
+  while (object && index < length) {
     object = object[toKey(path[index++])];
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -623,7 +623,7 @@ get = function(object, path) {
   path = Array.isArray(path) ? path : castPath(path, object);
   index = 0;
   length = path.length;
-  while (object !== null && index < length) {
+  while (object && index < length) {
     object = object[toKey(path[index++])];
   }
   if (index && index === length) {

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -417,6 +417,6 @@ Print the header line if the option "header" is "true".
       else castPath path, object
       index = 0
       length = path.length
-      while object isnt null and index < length
+      while object and index < length
         object = object[toKey(path[index++])]
       if index && index is length then object else undefined


### PR DESCRIPTION
Hi!

My unit tests started breaking with the update `5.3.0` -> `5.3.1`.

It is related to the new `get` method that was extracted from `lodash`, where you check for `object !== null`, while in my case, the value is undefined, thus throwing `TypeError: Cannot read property '2Template' of undefined` on the line after.

(I took a while until understand that I should change the coffee.md file until getting it to work I have never worked with coffee before haha)

I'm also pretty unsure about where/how to unit test this thing, I didn't find a lot of test cases with objects.
If this is a must, please help me how to approach this.