### PR TITLE
Fix command to generate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ test`. It will install mocha and its dependencies in your project "node_modules"
 directory and run the test suite. The tests run against the CoffeeScript source
 files.
 
-To generate the JavaScript files, run `npm run coffee`.
+To generate the JavaScript files, run `npm run build`.
 
 The test suite is run online with
 [Travis](https://travis-ci.org/#!/adaltas/node-csv-stringify). See the [Travis


### PR DESCRIPTION
Fixed misstake found in README.md.
After 38b3bcf2cff038234aa2bf9e8a44d1dca4317e9b, `npm run coffee` seems to be replaced by `npm run build`.
