### PR TITLE
fix(bom): BOM should be included when requested in sync

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -18,5 +18,8 @@ module.exports = function(records, options={}){
     stringifier.write(record) 
   }
   stringifier.end()
-  return data.join('')
+  const res = data.join('');
+  return options.bom
+    ? '\ufeff' + res
+    : res;
 }

--- a/test/option.bom.coffee
+++ b/test/option.bom.coffee
@@ -1,5 +1,6 @@
 
 stringify = require '../lib'
+stringifySync = require '../lib/sync'
 
 describe 'Option `bom`', ->
   
@@ -23,3 +24,23 @@ describe 'Option `bom`', ->
     ], bom: false, (err, data) ->
       data.should.eql 'ok\n'
       next()
+
+  describe 'sync ', ->
+    it 'validate', ->
+      (->
+        stringifySync [], bom: 'invalid'
+      ).should.throw
+        code: 'CSV_OPTION_BOOLEAN_INVALID_TYPE'
+        message: 'option `bom` is optional and must be a boolean value, got "invalid"'
+
+    it 'value is `true`', ->
+      res = stringifySync [
+        value: 'ok'
+      ], bom: true
+      res.should.eql '\ufeffok\n'
+
+    it 'value is `false`', ->
+      res = stringifySync [
+        value: 'ok'
+      ], bom: false
+      res.should.eql 'ok\n'


### PR DESCRIPTION
Fixes #114

I think the issues happens because `stringifier.push` ismodified
https://github.com/adaltas/node-csv-stringify/blob/ece5cc403f1c6a1e8bdd4c4b08775998fadfe9e6/lib/sync.js#L12

after the BOM is pushed
https://github.com/adaltas/node-csv-stringify/blob/ece5cc403f1c6a1e8bdd4c4b08775998fadfe9e6/lib/index.js#L53